### PR TITLE
Column-major option for panel_position_iterator

### DIFF
--- a/panels/_locators.py
+++ b/panels/_locators.py
@@ -109,10 +109,25 @@ class PanelSizeLocator(object):
         return (convert_units(self.figwidth, self.units, units),
                 convert_units(self.figheight, self.units, units))
 
-    def panel_position_iterator(self):
-        """Returns a generator of panel positions."""
-        return (self.panel_position(r, c)
-                for r in range(self.rows) for c in range(self.columns))
+    def panel_position_iterator(self, major='row'):
+        """Returns a generator of panel positions.
+
+        Keyword argument:
+
+        major (default='row'): str
+           The order in which panels are iterated over (row-major or column-
+           major).
+
+        """
+        if major == 'row':
+            return (self.panel_position(r, c)
+                    for r in range(self.rows) for c in range(self.columns))
+        elif major == 'column':
+            return (self.panel_position(r, c)
+                    for c in range(self.columns) for r in range(self.rows))
+        else:
+            raise ValueError('the "major" keyword must be either "row" or '
+                             '"column"')
 
     def panel_position(self, row, column):
         """

--- a/panels/tests/test_PanelSizeLocator.py
+++ b/panels/tests/test_PanelSizeLocator.py
@@ -23,7 +23,7 @@ import pytest
 
 from panels import PanelSizeLocator
 from panels.tests import (check_panels_in_figure, gridsize_st, length_st,
-                          offset_st)
+                          offset_st, almost_equal)
 
 
 #: Length units to generate test cases for.
@@ -199,3 +199,27 @@ def test_with_pad_and_sep(rows, columns, panelwidth, panelheight, hsep, vsep,
     assert figheight == (padtop + rows * panelheight +
                          (rows - 1) * vsep + padbottom)
     check_panels_in_figure(l)
+
+
+#-----------------------------------------------------------------------
+# Tests for iterating over panels.
+#-----------------------------------------------------------------------
+
+@given(rows=gridsize_st, columns=gridsize_st)
+def test_iterate_row_major(rows, columns):
+    l = PanelSizeLocator(rows, columns, 1, 1)
+    dx = 1. / columns
+    dy = 1. / rows
+    for n, pp in enumerate(l.panel_position_iterator()):
+        assert almost_equal((n % columns) * dx, pp[0])
+        assert almost_equal(1 - (n // columns + 1) * dy, pp[1])
+
+
+@given(rows=gridsize_st, columns=gridsize_st)
+def test_iterate_column_major(rows, columns):
+    l = PanelSizeLocator(rows, columns, 1, 1)
+    dx = 1. / columns
+    dy = 1. / rows
+    for n, pp in enumerate(l.panel_position_iterator(order='column')):
+        assert almost_equal((n // rows) * dx, pp[0])
+        assert almost_equal(1 - (n % rows + 1) * dy, pp[1])


### PR DESCRIPTION
At present the generator returned by panel_position_iterator goes along the first row of panels, then along the second row, etc. (i.e., row major).  This PR keeps the existing behaviour as the default but allows the user to choose column-major behaviour instead when calling panel_position_iterator.